### PR TITLE
fix gallery part

### DIFF
--- a/themes/ctrl-lab/layouts/_default/research.html
+++ b/themes/ctrl-lab/layouts/_default/research.html
@@ -113,7 +113,7 @@
 
             
 
-            {{ with $gallery := .Site.GetPage "/gallery" }}
+            {{ with $gallery := .Site.GetPage "/research/gallery" }}
                 {{ $sortedList := slice }}
                 {{ range $gallery.Params.gallery_item }}
                     {{ $sortedList = $sortedList | append . }}


### PR DESCRIPTION
ギャラリーが出力されなくなってたので，直しました．  

~ヘッダーのナビゲーションの表示もおかしくなっていますが，手元でちゃんとは再現できず．．  
複数回ビルド（?）しないと [$currentPage.Site.Menus.main](https://github.com/ctrl-kuaero/labsite/blob/2743a147f6cc3f2a903ce2b19fcd54b040815597/themes/ctrl-lab/layouts/partials/nav.html#L17) の取り方が不安定な感は若干ありました．~